### PR TITLE
FP6: Add double tap to wake and vibrator

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -316,6 +316,9 @@ PRODUCT_COPY_FILES += \
 # Screen density
 TARGET_SCREEN_DENSITY := xxxhdpi
 
+# Screen tap-to-wake
+TARGET_TAP_TO_WAKE_NODE := /sys/devices/platform/soc/ac0000.qcom,qupv3_0_geni_se/a80000.spi/spi_master/spi0/spi0.0/gesture_wakeup
+
 # Soong namespaces
 PRODUCT_SOONG_NAMESPACES += \
     $(LOCAL_PATH)

--- a/modules/modules.load.recovery.volcano
+++ b/modules/modules.load.recovery.volcano
@@ -235,7 +235,6 @@ qcom-cpufreq-hw-debug.ko
 qcom_lpm.ko
 leds-qti-flash.ko
 leds-qti-tri-led.ko
-leds-qpnp-vibrator-ldo.ko
 qcom_pil_info.ko
 rproc_qcom_common.ko
 qcom_q6v5.ko

--- a/modules/modules.load.volcano
+++ b/modules/modules.load.volcano
@@ -126,7 +126,6 @@ qcom-cpufreq-hw-debug.ko
 qcom_lpm.ko
 leds-qti-flash.ko
 leds-qti-tri-led.ko
-leds-qpnp-vibrator-ldo.ko
 qcom_pil_info.ko
 rproc_qcom_common.ko
 qcom_q6v5.ko

--- a/overlay/FrameworksResTarget_Vendor/res/values/config.xml
+++ b/overlay/FrameworksResTarget_Vendor/res/values/config.xml
@@ -46,4 +46,7 @@
          Note: If the display supports multiple resolutions, please define the path config based on
          the highest resolution so that it can be scaled correctly in each resolution. -->
     <string name="config_mainDisplayShape" translatable="false">M20 0h1040s20 0 20 20v2360s0 20 -20 20h-1040s-20 0 -20 -20v-2360s0 -20 20 -20</string>
+
+     <!-- Whether device supports double tap to wake -->
+    <bool name="config_supportDoubleTapWake">true</bool>
 </resources>

--- a/rootdir/etc/init.target.rc
+++ b/rootdir/etc/init.target.rc
@@ -165,6 +165,12 @@ on post-fs-data
     chown system system /sys/class/leds/aw_vibrator/activate_mode
     chown system system /sys/class/leds/aw_vibrator/gain
 
+# add tap-to-wake
+    wait /sys/devices/platform/soc/ac0000.qcom,qupv3_0_geni_se/a80000.spi/spi_master/spi0/spi0.0/gesture_wakeup 20
+    chown system system /sys/devices/platform/soc/ac0000.qcom,qupv3_0_geni_se/a80000.spi/spi_master/spi0/spi0.0/gesture_wakeup
+    chmod 0660 /sys/devices/platform/soc/ac0000.qcom,qupv3_0_geni_se/a80000.spi/spi_master/spi0/spi0.0/gesture_wakeup
+# add tap-to-wake
+
 
 on early-boot
     verity_update_state


### PR DESCRIPTION
Depends on:
- https://github.com/ArianK16a/android_kernel_fairphone_sm7635-modules/pull/1
- https://github.com/ArianK16a/android_kernel_fairphone_sm7635/pull/1

Fixes missing double tap to wake and #13 