### PR TITLE
FP6: Add stock camera support

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -140,6 +140,14 @@ PRODUCT_COPY_FILES += \
     frameworks/native/data/etc/android.hardware.camera.full.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.hardware.camera.full.xml \
     frameworks/native/data/etc/android.hardware.camera.raw.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/android.hardware.camera.raw.xml
 
+PRODUCT_PACKAGES += \
+    android.frameworks.cameraservice.common@2.0 \
+    android.frameworks.cameraservice.common-V1-ndk \
+
+# CAS
+PRODUCT_PACKAGES += \
+    com.android.hardware.cas
+
 # Display
 PRODUCT_PACKAGES += \
     android.hardware.graphics.mapper@4.0-impl-qti-display \

--- a/extract-files.py
+++ b/extract-files.py
@@ -97,6 +97,23 @@ blob_fixups: blob_fixups_user_type = {
             'android.media.audio.common.types-V2-cpp.so',
             'android.media.audio.common.types-V4-cpp.so',
         ),
+    'vendor/lib64/libcamera2ndk_vendor.so': blob_fixup()
+        .replace_needed(
+            'android.hardware.graphics.common-V5-ndk.so',
+            'android.hardware.graphics.common-V6-ndk.so',
+        )
+        .replace_needed(
+            'android.media.audio.common.types-V2-cpp.so',
+            'android.media.audio.common.types-V4-cpp.so',
+        )
+        .replace_needed(
+            'android.frameworks.cameraservice.device-V1-ndk.so',
+            'android.frameworks.cameraservice.device-V3-ndk.so',
+        )
+        .replace_needed(
+            'android.frameworks.cameraservice.service-V1-ndk.so',
+            'android.frameworks.cameraservice.service-V3-ndk.so',
+        ),
     'vendor/etc/init/tctd.rc': blob_fixup()
         .regex_replace('.+seclabel.+\n', ''),
     'vendor/etc/seccomp_policy/wfdhdcphalservice.policy': blob_fixup()

--- a/properties/odm.prop
+++ b/properties/odm.prop
@@ -1,2 +1,11 @@
 # Qti
 ro.vendor.qti.va_odm.support=1
+ro.vendor.qti.va_aosp.support=1
+persist.vendor.camera.fprom=1
+ro.boot.vendor.qspa.nsp=enabled
+ro.boot.vendor.qspa.sensors=enabled
+ro.boot.vendor.qspa.spss=enabled
+ro.boot.vendor.qspa.video=enabled
+ro.boot.vendor.qspa.wlan=enabled
+vendor.camera.siq.empty_lib=0
+vendor.tinfo.kb.device_id=Fairphone_FP6_0000012331

--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -582,6 +582,16 @@ vendor/lib64/vendor.qti.hardware.camera.aon-service-impl.so
 vendor/lib64/vendor.qti.hardware.camera.offlinecamera-service-impl.so
 vendor/lib64/vendor.qti.hardware.camera.postproc@1.0-service-impl.so
 vendor/lib64/vendor.tcl.camera.algoservice-V2-ndk.so
+system_ext/bin/fpconfig_util
+system_ext/etc/init/fpconfig_util.rc
+system_ext/etc/public.libraries-tct.txt  
+system_ext/lib64/libtctcameraalgo_jni.tct.so;DISABLE_CHECKELF;DISABLE_DEPS
+system_ext/lib64/vendor.qti.hardware.seccam@1.0.so
+system/lib64/android.hardware.audio.sounddose-V2-ndk.so
+system/lib64/vendor.tcl.camera.algoservice-V2-ndk.so:system/lib64/vendor.tcl.camera.algoservice-V2-ndk.so;MODULE=system.vendor.tcl.camera.algoservice-V2-ndk
+vendor/bin/aecxsimulator;DISABLE_CHECKELF;DISABLE_DEPS
+vendor/etc/init/algoservice-default.rc
+vendor/lib64/libcamera2ndk_vendor.so
 
 # Camera firmware
 vendor/firmware/CAMERA_ICP.b00


### PR DESCRIPTION
This aims to fix #23 

Current status is that one camera mode is missing (slowmo)

FP stock camera app can howver be used as a user app, and allow all the advanced mode to function (various EIS mode, macro, pano, time-lapse, ..)